### PR TITLE
navbar: Move "Code of Conduct" to the end

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -6,7 +6,6 @@
     </div>
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">
-        <li><a href="{{ site.root }}/conduct/">Code of Conduct</a></li>
 	{% unless site.is_workshop %}
         <li><a href="{{ site.root }}/setup/">Setup</a></li>
         <li class="dropdown">
@@ -28,6 +27,7 @@
         </li>
 	{% endunless %}
         <li><a href="{{ site.root }}/license/">License</a></li>
+        <li><a href="{{ site.root }}/conduct/">Code of Conduct</a></li>
       </ul>
       <form class="navbar-form navbar-right" role="search" id="search" onsubmit="google_search(); return false;">
         <div class="form-group">


### PR DESCRIPTION
This "how do I interact with this project" meta information is similar
to the license, and the current README links to both the license and
code of conduct at the end of the "Contributing" section.  With this
shift, the information we're explicitly teaching is on the left of the
navbar, and as you go right the navbar entries become more meta.