### PR TITLE
01-tooling: Drop remotes from fork/clone discussion

### DIFF
--- a/_episodes/01-tooling.md
+++ b/_episodes/01-tooling.md
@@ -25,8 +25,7 @@ Git uses the term *clone* to mean "a copy of a repository",
 while GitHub uses the term *fork* to mean "a copy of a GitHub-hosted repo that is also hosted on GitHub"
 and the term *clone* to mean "a copy of a GitHub-hosted repo that's located on someone else's machine".
 In both cases,
-the duplicate has a remote called `origin` that points to the original repo;
-other remotes can be added manually.
+the duplicate has a reference that points to the original repo.
 
 A user on GitHub can only have one fork of a particular repo.
 This is a problem for us because an author may be involved in writing several lessons,


### PR DESCRIPTION
GitHub repositories know the repository they were forked from (sort of
like the usual 'origin' remote), but I'm not aware of them having
other remote-like references.

Besides dropping the "other remotes" bit, soften the 'origin' wording.
I'm not sure if GitHub uses 'origin' remotes or not to track the
parent repository, and the implementation details matter less than the
fact that there *is* a reference of some sort to the parent.