### PR TITLE
_includes/episode_footer.html: Add prev/next links to the footer

### DIFF
--- a/_includes/episode_footer.html
+++ b/_includes/episode_footer.html
@@ -1,0 +1,24 @@
+{% comment %}
+    Find previous and next episodes (if any).
+{% endcomment %}
+{% for episode in site.episodes  %}
+  {% if episode.title == page.title %}
+    {% unless forloop.first %}
+      {% assign prev_episode = prev %}
+    {% endunless %}
+    {% unless forloop.last %}
+      {% assign next_episode = site.episodes[forloop.index] %}
+    {% endunless %}
+  {% endif %}
+  {% assign prev = episode %}
+{% endfor %}
+<div class="row">
+  <div class="col-md-1">
+    <h3>{% if prev_episode %}<a href="{{ site.root }}/{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left"></span></a>{% endif %}</h3>
+  </div>
+  <div class="col-md-10">
+  </div>
+  <div class="col-md-1">
+    <h3>{% if next_episode %}<a href="{{ site.root }}/{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right"></span></a>{% endif %}</h3>
+  </div>
+</div>

--- a/_layouts/episode.html
+++ b/_layouts/episode.html
@@ -5,3 +5,4 @@ layout: base
 {% include episode_overview.html %}
 {{content}}
 {% include episode_keypoints.html %}
+{% include episode_footer.html %}


### PR DESCRIPTION
Jumping back up to the top of the page so you can navigate between
eposodes is tedious.  In most cases, the reader will be at the bottom
of the page when they want to go to the next episode, so this commit
puts that link there for them.

There's probably some way to reuse the logic from
`_includes/episode_title.html` here, but I haven't dug through the
Jekyll docs to find it.

I haven't tested this to see if it works or how it looks.  We
certainly want to test it before merging, and may want additional
styling (an hrule?) to separate this footer from the episode's main
content.