### PR TITLE
02-formatting: Fix "lerners's" -> "learners'" typo

### DIFF
--- a/_episodes/02-formatting.md
+++ b/_episodes/02-formatting.md
@@ -124,7 +124,7 @@ The [template]({{ site.template_repo }}) provides three styles for code blocks:
 > ## Why No Syntax Highlighting?
 >
 > We do not use syntax highlighting for code blocks
-> because some learners's systems won't do it,
+> because some learners' systems won't do it,
 > or will do it differently than what they see on screen.
 {: .callout}
 


### PR DESCRIPTION
I'd rather drop this section [1], but as long as it stays we might as
well fix the plural possessive ;).

[1]: https://github.com/gvwilson/new-lesson-example/issues/11