### PR TITLE
03-organization: Drop _extras/contributing.md reference

### DIFF
--- a/_episodes/03-organization.md
+++ b/_episodes/03-organization.md
@@ -51,7 +51,6 @@ which should *not* be modified:
 *   `CONDUCT.md`: the code of conduct.
 *   `LICENSE.md`: the lesson license.
 *   `Makefile`: commands for previewing the site, cleaning up junk, etc.
-*   `_extras/contributing.md`: contribution guidelines.
 
 ## Common Files
 


### PR DESCRIPTION
This file was removed in 2e05819f (Naming layouts and inclusions more
clearly, 2016-04-19).