### PR TITLE
03-organization: Motivate AUTHORS by appealing to convenience

### DIFF
--- a/_episodes/03-organization.md
+++ b/_episodes/03-organization.md
@@ -67,7 +67,7 @@ and is *not* included in the generated website.
 ### `AUTHORS`
 
 The names and email addresses of authors, one per line.
-This file is used to map Git contributions to real identities when the lesson is published.
+This file provides a more convenient way to view contributors than walking the Git history.
 
 ### `CITATION`
 


### PR DESCRIPTION
The file is not *needed* for anything, because the information is in
the Git history.  It's just easier to access when it's committed to a
file in the repo than it is to ask curious folks to clone the repo and
run ‘git shortlog’, etc.