### PR TITLE
Adding previous/next links at the bottom of episode pages.

### DIFF
--- a/_includes/episode_find_prev_next.html
+++ b/_includes/episode_find_prev_next.html
@@ -1,0 +1,14 @@
+{% comment %}
+    Find previous and next episodes (if any).
+{% endcomment %}
+{% for episode in site.episodes  %}
+  {% if episode.url == page.url %}
+    {% unless forloop.first %}
+      {% assign prev_episode = prev %}
+    {% endunless %}
+    {% unless forloop.last %}
+      {% assign next_episode = site.episodes[forloop.index] %}
+    {% endunless %}
+  {% endif %}
+  {% assign prev = episode %}
+{% endfor %}

--- a/_includes/episode_title.html
+++ b/_includes/episode_title.html
@@ -1,17 +1,4 @@
-{% comment %}
-    Find previous and next episodes (if any).
-{% endcomment %}
-{% for episode in site.episodes  %}
-  {% if episode.url == page.url %}
-    {% unless forloop.first %}
-      {% assign prev_episode = prev %}
-    {% endunless %}
-    {% unless forloop.last %}
-      {% assign next_episode = site.episodes[forloop.index] %}
-    {% endunless %}
-  {% endif %}
-  {% assign prev = episode %}
-{% endfor %}
+{% include episode_find_prev_next.html %}
 <div class="row">
   <div class="col-md-1">
     <h3>{% if prev_episode %}<a href="{{ site.root }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left"></span></a>{% endif %}</h3>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,10 +1,23 @@
+{% comment %}
+  Generic footer: prev_episode and next_episode will only be set if this is an episode,
+  so previous/next link arrows will not appear for other kinds of pages.
+{% endcomment %}
+{% include episode_find_prev_next.html %}
 <hr/>
 <footer class="row">
-  <div class="col-md-12 footertext">
-    Copyright &copy; 2016 Software Carpentry Foundation
-    /
-    <a href="{{ site.root }}/license/">License</a>
-    /
-    <a href="mailto:{{site.email}}">Contact</a>
+  <div class="col-md-1">
+    <h4>{% if prev_episode %}<a href="{{ site.root }}{{ prev_episode.url }}"><span class="glyphicon glyphicon-menu-left"></span></a>{% endif %}</h4>
+  </div>
+  <div class="col-md-10 footertext">
+    <h4>
+      Copyright &copy; 2016 Software Carpentry Foundation
+      /
+      <a href="{{ site.root }}/license/">License</a>
+      /
+      <a href="mailto:{{site.email}}">Contact</a>
+    </h4>
+  </div>
+  <div class="col-md-1">
+    <h4>{% if next_episode %}<a href="{{ site.root }}{{ next_episode.url }}"><span class="glyphicon glyphicon-menu-right"></span></a>{% endif %}</h4>
   </div>
 </footer>


### PR DESCRIPTION
1.  Put prev/next finding code into separate include.
2.  Modify episode_title to use that.
3.  Include it in the footer and add prev/next arrows if there's a match.

Note: the prev/next finding code must be added to *both* episode_title and footer because variables set in includes aren't exported to other includes.

Replaces #10. @wking please review.