### PR TITLE
Trying to get syntax highlighting to work.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -62,5 +62,5 @@ exclude:
   - Makefile
   - bin
 
-# Turn off built-in syntax highlighting.
-highlighter: false
+# Syntax highlighter.
+highlighter: route

--- a/_episodes/02-formatting.md
+++ b/_episodes/02-formatting.md
@@ -120,18 +120,34 @@ for thing in collection:
 The class specified at the bottom using an opening curly brace and colon,
 the class identifier with a leading dot,
 and a closing curly brace.
-The [template]({{ site.template_repo }}) provides three styles for code blocks:
+The [template]({{ site.template_repo }}) provides four styles for code blocks:
 
 *   `.error`: error messages.
 *   `.output`: program output.
-*   `.source`: program source.
+*   `.python`: Python program source (syntax highlighted).
+*   `.source`: generic program source.
 
-> ## Why No Syntax Highlighting?
->
-> We do not use syntax highlighting for code blocks
-> because some learners' systems won't do it,
-> or will do it differently than what they see on screen.
-{: .callout}
+The difference between `.python` and `.source` is shown by:
+
+<div class="row">
+  <div class="col-md-6" markdown="1">
+~~~
+# Plain source
+def mangle(a, b):
+    for i in range(a):
+      print(b)
+~~~
+{: .source}
+  </div>
+  <div class="col-md-6" markdown="1">
+{% highlight python %}
+# Python source
+def mangle(a, b):
+    for i in range(a):
+      print(b)
+{% endhighlight %}
+  </div>
+</div>
 
 ## Special Blockquotes
 

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" type="text/css" href="{{ site.root }}/assets/css/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ site.root }}/assets/css/bootstrap-theme.css" />
     <link rel="stylesheet" type="text/css" href="{{ site.root }}/assets/css/lesson.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.root }}/assets/css/syntax.css" />
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/assets/css/syntax.css
+++ b/assets/css/syntax.css
@@ -1,0 +1,61 @@
+// From https://raw.githubusercontent.com/mojombo/tpw/master/css/syntax.css
+.highlight  { background: #ffffff; }
+.highlight .c { color: #999988; font-style: italic } /* Comment */
+.highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight .k { font-weight: bold } /* Keyword */
+.highlight .o { font-weight: bold } /* Operator */
+.highlight .cm { color: #999988; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
+.highlight .c1 { color: #999988; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight .gd .x { color: #000000; background-color: #ffaaaa } /* Generic.Deleted.Specific */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #aa0000 } /* Generic.Error */
+.highlight .gh { color: #999999 } /* Generic.Heading */
+.highlight .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight .gi .x { color: #000000; background-color: #aaffaa } /* Generic.Inserted.Specific */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #555555 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #aaaaaa } /* Generic.Subheading */
+.highlight .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight .kc { font-weight: bold } /* Keyword.Constant */
+.highlight .kd { font-weight: bold } /* Keyword.Declaration */
+.highlight .kp { font-weight: bold } /* Keyword.Pseudo */
+.highlight .kr { font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #445588; font-weight: bold } /* Keyword.Type */
+.highlight .m { color: #009999 } /* Literal.Number */
+.highlight .s { color: #d14 } /* Literal.String */
+.highlight .na { color: #008080 } /* Name.Attribute */
+.highlight .nb { color: #0086B3 } /* Name.Builtin */
+.highlight .nc { color: #445588; font-weight: bold } /* Name.Class */
+.highlight .no { color: #008080 } /* Name.Constant */
+.highlight .ni { color: #800080 } /* Name.Entity */
+.highlight .ne { color: #990000; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #990000; font-weight: bold } /* Name.Function */
+.highlight .nn { color: #555555 } /* Name.Namespace */
+.highlight .nt { color: #000080 } /* Name.Tag */
+.highlight .nv { color: #008080 } /* Name.Variable */
+.highlight .ow { font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mf { color: #009999 } /* Literal.Number.Float */
+.highlight .mh { color: #009999 } /* Literal.Number.Hex */
+.highlight .mi { color: #009999 } /* Literal.Number.Integer */
+.highlight .mo { color: #009999 } /* Literal.Number.Oct */
+.highlight .sb { color: #d14 } /* Literal.String.Backtick */
+.highlight .sc { color: #d14 } /* Literal.String.Char */
+.highlight .sd { color: #d14 } /* Literal.String.Doc */
+.highlight .s2 { color: #d14 } /* Literal.String.Double */
+.highlight .se { color: #d14 } /* Literal.String.Escape */
+.highlight .sh { color: #d14 } /* Literal.String.Heredoc */
+.highlight .si { color: #d14 } /* Literal.String.Interpol */
+.highlight .sx { color: #d14 } /* Literal.String.Other */
+.highlight .sr { color: #009926 } /* Literal.String.Regex */
+.highlight .s1 { color: #d14 } /* Literal.String.Single */
+.highlight .ss { color: #990073 } /* Literal.String.Symbol */
+.highlight .bp { color: #999999 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #008080 } /* Name.Variable.Class */
+.highlight .vg { color: #008080 } /* Name.Variable.Global */
+.highlight .vi { color: #008080 } /* Name.Variable.Instance */
+.highlight .il { color: #009999 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
This attempts to address #11 by addig syntax highlighting for Python following the instructions at https://jekyllrb.com/docs/templates/.  Unfortunately, it doesn't seem to take effect.

1.  `rouge` gem installed.
1.  `_config.yml` now has `highlighter: rouge`.
1.  GitHub CSS file for highlighting downloaded and installed in `assets/css/syntax.css`.
1.  `_layouts/base.html` modified to include that CSS.
1.  `_episodes/02-formatting.md` now has side-by-side display of two code blocks, one formatted as `.source`, the other using syntax highlighting.

...but there's no highlighting.